### PR TITLE
Reduce exec time of proc option tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.11.0
 -----------------------
 
-- add "-n NUM" option to limit number of processes.  Thanks Timothée
+- add "-n NUMPROC" option to set number of processes.  Thanks Timothée
   Mazzucotelli.
 
 0.10.0
@@ -41,7 +41,7 @@
 0.9.1
 -----------------------
 
-- fix issue5 - small adjustments to work with latest tox-1.4.3 version 
+- fix issue5 - small adjustments to work with latest tox-1.4.3 version
 
 0.9
 -----------------------

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ detox is the distributed version of [tox](https://pypi.org/project/tox/).  It ma
 
 in the same way and with the same options with which you would run `tox`, see the [tox home page](http://tox.readthedocs.io) for more info.
 
+Additionally, detox offers a `-n` or `--num` option to set the number of concurrent processes to use.
+
 Please file issues as ["tox" issues](https://github.com/tox-dev/tox/issues) using a "detox: " prefix in the issue title.
 
 ## Note

--- a/detox/proc.py
+++ b/detox/proc.py
@@ -146,7 +146,7 @@ class Detox:
                     self.toxsession.runtestenv(venv, redirect=True)
 
     def runtestsmulti(self, envlist):
-        pool = GreenPool(size=self._toxconfig.option.proclimit)
+        pool = GreenPool(size=self._toxconfig.option.numproc)
         for env in envlist:
             pool.spawn_n(self.runtests, env)
         pool.waitall()

--- a/detox/tox_proclimit.py
+++ b/detox/tox_proclimit.py
@@ -13,10 +13,12 @@ def tox_addoption(parser):
                 "%s is an invalid positive int value" % value)
         return ivalue
 
+    num_proc = multiprocessing.cpu_count()
     parser.add_argument(
         "-n", "--num",
         type=positive_integer,
         action="store",
-        default=multiprocessing.cpu_count(),
-        dest="proclimit",
-        help="limit the number of concurrent processes.")
+        default=num_proc,
+        dest="numproc",
+        help="set the number of concurrent processes "
+             "(default %s)." % num_proc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,12 +54,6 @@ def create_example3(tmpdir):
 
         [testenv:py1]
         [testenv:py2]
-        [testenv:py3]
-        [testenv:py4]
-        [testenv:py5]
-        [testenv:py6]
-        [testenv:py7]
-        [testenv:py8]
     """))
     tmpdir.join("example3", "__init__.py").ensure()
 
@@ -171,4 +165,3 @@ def test_hang(testdir):
     result = testdir.runpytest()
     assert "failed to timeout" not in result.stdout.str()
     result.stdout.fnmatch_lines(["*Timeout: 0.01*"])
-

--- a/tests/test_detox.py
+++ b/tests/test_detox.py
@@ -96,7 +96,7 @@ class TestProcLimitOption:
     def test_runtestmulti(self):
         class MyConfig:
             class MyOption:
-                proclimit = 4
+                numproc = 7
             option = MyOption()
 
         l = []
@@ -115,20 +115,20 @@ class TestProcLimitOption:
             d.runtestsmulti(['env1', 'env2', 'env3'])  # Fake env list
 
         assert l[0] == {}  # When building Detox object
-        assert l[1] == {'size': 4}  # When calling runtestsmulti
+        assert l[1] == {'size': 7}  # When calling runtestsmulti
 
-    @pytest.mark.timeout(30)
+    @pytest.mark.timeout(60)
     def test_runtests(self, cmd):
         now1 = datetime.now()
-        cmd.rundetox("-n", "1", "-epy1,py2,py3,py4,py5,py6,py7,py8")
+        cmd.rundetox("-n", "1", "-epy1,py2")
         then1 = datetime.now()
         delta1 = then1 - now1
-        assert delta1 >= timedelta(seconds=8)
+        assert delta1 >= timedelta(seconds=2)
 
-        now4 = datetime.now()
-        cmd.rundetox("-n", "4", "-epy1,py2,py3,py4,py5,py6,py7,py8")
-        then4 = datetime.now()
-        delta4 = then4 - now4
-        assert delta4 >= timedelta(seconds=2)
+        now2 = datetime.now()
+        cmd.rundetox("--num", "2", "-epy1,py2")
+        then2 = datetime.now()
+        delta2 = then2 - now2
+        assert delta2 >= timedelta(seconds=1)
 
-        assert delta1 >= delta4, 'pool size=4 took much time than pool size=1'
+        assert delta1 >= delta2, 'pool size=2 took much time than pool size=1'


### PR DESCRIPTION
This commit changes the name of the -n, --num option to -p, --processes to be more explicit.
It also change the name of the destination variable to numproc instead of proclimit since this option allows to set (and not only limit) the number of concurrent processes to use.

The help text will show the default number of processes that will be used.

Record and explode test now uses 7 as number of processes instead of 4, 4 being too common.

Functionnal test now tries to execute 2 jobs (instead of 8), one time with one process and a second time with two processes. Each job take 1 second to execute (sleep 1). The timeout has been raised from 30 seconds to 1 minute.