### PR TITLE
Add support for running as `python -m detox ...`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+/.cache/
+/.tox/
+/detox.egg-info/
+**/__pycache__/

--- a/detox/__main__.py
+++ b/detox/__main__.py
@@ -1,0 +1,5 @@
+from detox.main import main
+
+# Enable ``python -m detox ...``.
+if __name__ == '__main__':
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+
+import subprocess
+import sys
+
+
+def invoke(command, success_codes=(0,)):
+    try:
+        output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        status = 0
+    except subprocess.CalledProcessError as error:
+        output = error.output
+        status = error.returncode
+    output = output.decode('utf-8')
+    if status not in success_codes:
+        raise Exception(
+            'Command %r return exit code %d and output: """%s""".' % (
+                command,
+                status,
+                output,
+            )
+        )
+    return status, output
+
+
+def test_run_as_module():
+    """Can be run as `python -m detox ...`."""
+    status, output = invoke([
+        sys.executable, '-m', 'detox', '--help',
+    ])
+    assert status == 0
+    assert output.startswith('usage:')


### PR DESCRIPTION
Fixes tox-dev/tox#468.