### PR TITLE
Wrap up virtual environment after creation

### DIFF
--- a/detox/main.py
+++ b/detox/main.py
@@ -20,4 +20,4 @@ def main(args=None):
     #detox.toxsession.report.line(
     #    "detox speed-up: %.2f (elapsed %.2f, cumulated %.2f)" % (
     #        cumulated / elapsed, elapsed, cumulated), bold=True)
-    return retcode
+    raise SystemExit(retcode)

--- a/detox/proc.py
+++ b/detox/proc.py
@@ -134,6 +134,7 @@ class Detox:
         if self.toxsession.config.skipsdist:
             venv, = self.getresources("venv:%s" % venvname)
             if venv:
+                venv.finish()
                 self.toxsession.runtestenv(venv, redirect=True)
         else:
             venv, sdist = self.getresources("venv:%s" % venvname, "sdist")


### PR DESCRIPTION
This is a solution for https://github.com/tox-dev/tox/issues/283 - detox does not completely wrap up the virtual environment after creating it, and keeps recreating the venv for every execution.

Native tox behavior for the `skipsdist` case is located at https://github.com/msabramo/tox/blob/master/tox/_cmdline.py#L444 - calling `venv.finish()` writes the necessary configuration so that this environment will be reused in future runs.