### PR TITLE
always use first path if a tuple is returned

### DIFF
--- a/detox/proc.py
+++ b/detox/proc.py
@@ -149,8 +149,11 @@ class Detox:
                 self.toxsession.runtestenv(venv, redirect=True)
         else:
             venv, sdist = self.getresources("venv:%s" % venvname, "sdist")
-            self._sdistpath = sdist
             if venv and sdist:
+                # tox >= 3.5 returns a tuple of paths rather than a path
+                # not knowing what I do, I'll simply use the first one ...
+                if isinstance(sdist, tuple):
+                    sdist = sdist[0]
                 if self.toxsession.installpkg(venv, sdist):
                     self.toxsession.runtestenv(venv, redirect=True)
 

--- a/tests/test_detox.py
+++ b/tests/test_detox.py
@@ -69,8 +69,9 @@ class TestDetoxExample1:
     pytestmark = [pytest.mark.example1, pytest.mark.timeout(20)]
 
     def test_createsdist(self, detox):
-        sdist, = detox.getresources("sdist")
-        assert sdist.check()
+        sdists, = detox.getresources("sdist")
+        for sdist in sdists:
+            assert sdist.check()
 
     def test_getvenv(self, detox):
         venv, = detox.getresources("venv:py")


### PR DESCRIPTION
hopefully fix #33

I did not investigate why installpkg now installs a tuple of several paths, but simply checking for it and using the first one at least fixes the tests. 

Maybe @gaborbernat can shed some light what the nature of the change is and if that fix is a viable solution.