### PR TITLE
use Session.evaluated_env_list to respect TOX_SKIP_ENV

### DIFF
--- a/detox/cli.py
+++ b/detox/cli.py
@@ -17,4 +17,4 @@ def main(args=None):
     detox = Detox(config)
     if not hasattr(config.option, "quiet_level") or not config.option.quiet_level:
         detox.startloopreport()
-    return detox.runtestsmulti(config.envlist)
+    return detox.runtestsmulti(detox.toxsession.evaluated_env_list())


### PR DESCRIPTION
fix #34 - I don't know if that will break compatibility with older version of tox, but we should at least try to be compatible with current versions of tox.