### PR TITLE
Specify encoding when reading README and CHANGELOG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
+import io
 from setuptools import setup
 
 
 def make_long_description():
-    with open("README.md") as f:
+    with io.open("README.md", encoding='UTF-8') as f:
         readme = f.read()
-    with open("CHANGELOG") as f:
+    with io.open("CHANGELOG", encoding='UTF-8') as f:
         changelog = f.read()
     return readme + "\n\n" + changelog
 


### PR DESCRIPTION
Otherwise, calling "setup.py build" can fail with:

Traceback (most recent call last):
  File "setup.py", line 15, in <module>
    long_description=make_long_description(),
  File "setup.py", line 8, in make_long_description
    changelog = f.read()
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position \
  2208: ordinal not in range(128)